### PR TITLE
Github actions: Use windows-2016

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [12.x]
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node-version: [14.x]
+        os: [ubuntu-latest, macOS-latest, windows-2016]
 
     steps:
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
For some reason, the esy build fails on windows-latest, so let's use windows-2016 for now.